### PR TITLE
Drop Python 3.8/3.9 support; replace cibuildwheel with simple test CI

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           package-dir: .
         env:
-          CIBW_BEFORE_BUILD: pip install numpy cython matplotlib biopython scipy distinctipy
+          CIBW_BEFORE_BUILD: pip install numpy cython
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_SKIP: "pp* *musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,35 +1,31 @@
-name: Build
+name: Test
 
 on: [push, pull_request]
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+  test:
+    name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
-
-      - name: "Build wheels"
-        uses: pypa/cibuildwheel@v2.16.5
+      - uses: actions/setup-python@v5
         with:
-          package-dir: .
-        env:
-          CIBW_BEFORE_BUILD: pip install numpy cython
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_SKIP: "pp* *musllinux*"
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_TEST_SKIP: "*_arm64"
-          CIBW_TEST_COMMAND: python {package}/tests/test_trviz.py
+          python-version: ${{ matrix.python-version }}
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install cython numpy
+
+      - name: Install trviz
+        run: pip install -e .
+
+      - name: Run tests
+        run: python tests/test_trviz.py

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         'matplotlib',
         'numpy',
-        'biopython',
+        'biopython<1.86',
         'scipy',
         'distinctipy',
     ],

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     classifiers=[
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -66,6 +64,6 @@ setup(
         'scipy',
         'distinctipy',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     ext_modules=extensions if not use_cython else [],
 )


### PR DESCRIPTION
Biopython 1.86 (released 2025) removed the deprecated Bio.Align.Applications module, which motif_aligner.py imports at module level. Without the pin, CI fails on cp310/cp311/cp312 wheels with ModuleNotFoundError before any test runs.

Long-term fix is to rewrite the muscle/clustalo wrappers using subprocess directly (as the mafft path already does), but pinning unblocks the CI for now.