### PR TITLE
fix: single-sequence input crash (v1.4.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trviz"
-version = "1.4.0"
+version = "1.4.1"
 description = "A python library for decomposing and visualizing tandem repeat sequences"
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -107,6 +107,20 @@ def test_trplot_with_user_provided_ax(visualizer, simple_inputs):
     plt.close(user_fig)
 
 
+def test_trplot_with_single_sequence(visualizer):
+    """Regression: clustering is a no-op for N=1, must not crash on empty distance matrix."""
+    fig, ax = visualizer.trplot(
+        aligned_labeled_repeats=["AAAB"],
+        sample_ids=["s1"],
+        symbol_to_motif={"A": "ACT", "B": "ACG"},
+        sort_by_clustering=True,  # the buggy path — was raising ValueError
+        output_name=None,
+    )
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, plt.Axes)
+    plt.close(fig)
+
+
 def test_plot_motif_color_map_returns_fig_and_ax(visualizer):
     symbol_to_motif = {"A": "ACT", "B": "ACG"}
     motif_counter = {"ACT": 3, "ACG": 1}

--- a/trviz/__init__.py
+++ b/trviz/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 # Library convention: attach a NullHandler so trviz never emits log records
 # unless the user explicitly configures logging in their application. See

--- a/trviz/visualizer.py
+++ b/trviz/visualizer.py
@@ -636,6 +636,11 @@ class TandemRepeatVisualizer:
 
         from trviz.utils import calculate_cost_with_dist_matrix, get_distance_matrix
 
+        # Clustering is a no-op for <2 sequences. scipy.linkage on an empty
+        # condensed distance matrix raises, so short-circuit here.
+        if len(aligned_labeled_repeats) < 2:
+            return list(sample_ids), list(aligned_labeled_repeats)
+
         distance_matrix = get_distance_matrix(symbol_to_motif)
         dist_mat = np.zeros([len(aligned_labeled_repeats), len(aligned_labeled_repeats)])
         for i in range(len(aligned_labeled_repeats)):


### PR DESCRIPTION
Closes #7 (Trviz fails when fasta contains one sequence).

## Bug fix (the main thing)

`generate_trplot()` crashed when given a single sequence because
`sort_by_clustering()` produced a 1×1 distance matrix → empty
condensed array → `scipy.linkage` raised `ValueError: The number
of observations cannot be determined on an empty distance matrix`.

The fix is a 3-line early return — clustering is a no-op for N<2.

This bug predates v1.4.0; not a regression from the recent viz API rewrite.

- Includes a regression test (\`test_trplot_with_single_sequence\`)
- Bumps version to 1.4.1

## CI fix (caught while investigating the v1.4.0 release-pipeline failure)

The new \`release.yml\` was using cibuildwheel's default manylinux image
(\`manylinux2014\`), but scipy 1.16+ stopped publishing wheels for it.
That made \`pip install <trviz wheel>\` during the test phase fall back
to a source build, which failed for lack of OpenBLAS in the container.

Bumped \`CIBW_MANYLINUX_X86_64_IMAGE\` to \`manylinux_2_28\` (AlmaLinux 8).
Without this, the v1.4.1 release would hit the same wall as v1.4.0 did.