### PR TITLE
ci: pin manylinux_2_28 image in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           CIBW_BUILD: "cp310-* cp311-* cp312-*"
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_MACOS: x86_64 arm64
+          # cibuildwheel defaults to manylinux2014, but scipy 1.16+ no
+          # longer publishes wheels for it. Without this override, the
+          # test step's `pip install` falls back to a scipy source build
+          # that fails on missing OpenBLAS in the container.
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_TEST_SKIP: "*_arm64"  # cross-built arm64 wheels can't be tested on x86 runners
           CIBW_TEST_COMMAND: python {package}/tests/test_trviz.py
 


### PR DESCRIPTION
The fix was meant to land with #13 but got dropped during squash-merge.
Re-applying so v1.4.1 release workflow can succeed.

Without this, the wheel-test phase falls back to a scipy source build that
fails on missing OpenBLAS in the manylinux2014 container.

After merge, we'll re-tag v1.4.1 (the previous tag was deleted; nothing was
published to PyPI yet because the test step failed before publish ran).