### PR TITLE
fix: label private motifs correctly in legend (v1.4.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trviz"
-version = "1.4.1"
+version = "1.4.2"
 description = "A python library for decomposing and visualizing tandem repeat sequences"
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/tests/test_motif_encoder.py
+++ b/tests/test_motif_encoder.py
@@ -1,0 +1,37 @@
+"""Tests for trviz.motif_encoder.MotifEncoder."""
+
+from trviz.motif_encoder import MotifEncoder
+from trviz.utils import PRIVATE_MOTIF_LABEL
+
+
+def test_private_motifs_attribute_lists_all_collapsed_motifs(tmp_path):
+    """When multiple distinct motifs share PRIVATE_MOTIF_LABEL, MotifEncoder
+    must expose all of them via .private_motifs so the legend can label the
+    private color correctly. symbol_to_motif itself only holds one arbitrary
+    private motif (intentional: many → one in the encoded space)."""
+    decomposed_trs = [
+        ["ACT"] * 4 + ["AAA"],
+        ["ACT"] * 4 + ["CCC"],
+        ["ACT"] * 4 + ["GGG"],
+        ["ACT"] * 5,
+    ]
+    encoder = MotifEncoder(private_motif_threshold=2)
+    encoder.encode(decomposed_trs, motif_map_file=str(tmp_path / "map.txt"), auto=False)
+
+    # All 3 single-occurrence motifs are private (count < threshold of 2)
+    assert set(encoder.private_motifs) == {"AAA", "CCC", "GGG"}
+
+    # symbol_to_motif still uses the lossy many-to-one shape
+    assert encoder.symbol_to_motif[PRIVATE_MOTIF_LABEL] in {"AAA", "CCC", "GGG"}
+
+    # All 3 private motifs map to the same symbol (the encoding's intent)
+    private_symbols = {encoder.motif_to_symbol[m] for m in ("AAA", "CCC", "GGG")}
+    assert private_symbols == {PRIVATE_MOTIF_LABEL}
+
+
+def test_private_motifs_empty_when_no_private_threshold(tmp_path):
+    """With private_motif_threshold=0, no motifs are private and the list is empty."""
+    decomposed_trs = [["ACT", "ACT"], ["ACT", "ACG"]]
+    encoder = MotifEncoder(private_motif_threshold=0)
+    encoder.encode(decomposed_trs, motif_map_file=str(tmp_path / "map.txt"), auto=False)
+    assert encoder.private_motifs == []

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -121,6 +121,29 @@ def test_trplot_with_single_sequence(visualizer):
     plt.close(fig)
 
 
+def test_plot_motif_color_map_labels_private_motifs(visualizer):
+    """The private color row should be labeled with a count of private motifs,
+    not one arbitrary motif's name."""
+    from trviz.utils import PRIVATE_MOTIF_LABEL
+
+    # 3 private motifs collapsed to PRIVATE_MOTIF_LABEL, plus one normal
+    symbol_to_motif = {PRIVATE_MOTIF_LABEL: "GGG", "a": "ACT"}
+    motif_counter = {"AAA": 1, "CCC": 1, "GGG": 1, "ACT": 17}
+    symbol_to_color = {PRIVATE_MOTIF_LABEL: "black", "a": "red"}
+    private_motifs = ["AAA", "CCC", "GGG"]
+
+    fig, ax = visualizer.plot_motif_color_map(
+        symbol_to_motif, motif_counter, symbol_to_color,
+        private_motifs=private_motifs,
+    )
+    labels = [t.get_text() for t in ax.get_yticklabels()]
+    # Some label should contain the private count, not just a single motif name
+    private_label = next((line for line in labels if "private" in line), None)
+    assert private_label is not None, f"expected a 'private' label, got {labels}"
+    assert "(3)" in private_label  # 3 private motifs
+    plt.close(fig)
+
+
 def test_plot_motif_color_map_returns_fig_and_ax(visualizer):
     symbol_to_motif = {"A": "ACT", "B": "ACG"}
     motif_counter = {"ACT": 3, "ACG": 1}

--- a/trviz/__init__.py
+++ b/trviz/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 # Library convention: attach a NullHandler so trviz never emits log records
 # unless the user explicitly configures logging in their application. See

--- a/trviz/main.py
+++ b/trviz/main.py
@@ -269,6 +269,7 @@ class TandemRepeatVizWorker:
             file_name=motif_map_output,
             figure_size=motif_map_size,
             close=close,
+            private_motifs=self.motif_encoder.private_motifs,
         )
 
         return fig, ax

--- a/trviz/motif_encoder.py
+++ b/trviz/motif_encoder.py
@@ -13,6 +13,11 @@ class MotifEncoder:
         self.motif_to_symbol = None
         self.score_matrix = None
         self.motif_counter = None
+        # All distinct motifs that share PRIVATE_MOTIF_LABEL after encoding.
+        # symbol_to_motif[PRIVATE_MOTIF_LABEL] only holds one arbitrary entry
+        # (the comprehension key is constant), so callers that want the full
+        # list of private motifs (e.g. the legend renderer) read this instead.
+        self.private_motifs: list = []
 
     @staticmethod
     def _divide_motifs_into_normal_and_private(motif_counter, private_motif_threshold):
@@ -130,10 +135,12 @@ class MotifEncoder:
 
             # Assign a code to all private motifs
             motif_to_symbol.update({motif: PRIVATE_MOTIF_LABEL for motif, _ in private_motifs.most_common()})
-            # TODO(B035): {PRIVATE_MOTIF_LABEL: motif for ...} produces only the last motif because
-            #             the comprehension key is constant. Likely intended a list or different
-            #             structure here. Investigate as a separate issue.
+            # symbol_to_motif[PRIVATE_MOTIF_LABEL] is intentionally one arbitrary
+            # private motif (the comprehension key is constant). The full list
+            # of private motifs is exposed via self.private_motifs below so the
+            # legend renderer can label the private color correctly.
             symbol_to_motif.update({PRIVATE_MOTIF_LABEL: motif for motif, _ in private_motifs.most_common()})  # noqa: B035
+            self.private_motifs = [motif for motif, _ in private_motifs.most_common()]
 
             # For normal motifs
             motif_to_symbol.update(

--- a/trviz/visualizer.py
+++ b/trviz/visualizer.py
@@ -55,6 +55,7 @@ class TandemRepeatVisualizer:
         dpi=300,
         ax=None,
         close=False,
+        private_motifs=None,
     ):
         """Generate a plot for motif color map.
 
@@ -108,8 +109,16 @@ class TandemRepeatVisualizer:
                 plt.Rectangle(box_position, box_width, box_height, linewidth=0, facecolor=color, edgecolor="white")
             )
             y_base_position -= 1
-            motif = symbol_to_motif[symbol]
-            text = f"{motif:<{max_motif_length + 2}}" + f"{motif_counter[motif]:>5}"
+            if symbol == PRIVATE_MOTIF_LABEL and private_motifs:
+                # The private color represents N distinct motifs that all share
+                # one symbol. Show "private (N)" + total count rather than one
+                # arbitrary motif name, which would mislead readers.
+                count = sum(motif_counter[m] for m in private_motifs)
+                label = f"private ({len(private_motifs)})"
+                text = f"{label:<{max_motif_length + 2}}" + f"{count:>5}"
+            else:
+                motif = symbol_to_motif[symbol]
+                text = f"{motif:<{max_motif_length + 2}}" + f"{motif_counter[motif]:>5}"
             yticklabels.append(text)
 
         ax.yaxis.tick_right()


### PR DESCRIPTION
The dict comprehension at \`motif_encoder.py:136\` produces a single-entry dict
because the key is constant — that part matches the design (many private motifs
intentionally share one symbol and one color). But \`plot_motif_color_map()\` was
then reading \`symbol_to_motif[PRIVATE_MOTIF_LABEL]\` to label the legend, so
the legend mislabeled the private color row as one arbitrary motif name.

## Fix

- \`MotifEncoder\` now exposes \`.private_motifs\` (the full list).
- \`plot_motif_color_map()\` accepts a \`private_motifs=\` kwarg. When given,
  the legend's private row reads \`private (N)\` with total count instead of
  a misleading single motif name.

## Backward compat

- \`symbol_to_motif\` keeps its existing \`dict[str, str]\` shape — no caller breakage.
- \`private_motifs=\` defaults to \`None\`, so old callers see no behavior change.

Bumps version to 1.4.2.